### PR TITLE
clear ripple on dragstart

### DIFF
--- a/src/ripple.js
+++ b/src/ripple.js
@@ -105,6 +105,7 @@ var Ripple = {
                 }, 850);
 
                 el.removeEventListener('mouseup', clearRipple, false);
+                el.removeEventListener('dragstart', clearRipple, false);
 
                 // After removing event set position to target to it's original one
                 // Timeout it's needed to avoid jerky effect of ripple jumping out parent target
@@ -130,6 +131,7 @@ var Ripple = {
 
             if(event.type === 'mousedown') {
                 el.addEventListener('mouseup', clearRipple, false);
+                el.addEventListener('dragstart', clearRipple, false);
             } else {
                 clearRipple();
             }


### PR DESCRIPTION
Clearing ripple on dragstart event fixes a bug when an anchor tag is being dragged so ripple doesn't disappear, as we only listen to mouseup event on that element.